### PR TITLE
cygwin-tilde

### DIFF
--- a/t/tilde.t
+++ b/t/tilde.t
@@ -9,57 +9,68 @@ use Test::More tests => 9;
 use ExtUtils::Helpers 'detildefy';
 
 SKIP: {
-	my $home = $ENV{USERPROFILE} || $ENV{HOME} || undef;
+    my $home = $ENV{USERPROFILE} || $ENV{HOME} || undef;
 
-	if ($^O eq 'VMS') {
-		# Convert the path to UNIX format, trim off the trailing slash
-		$home = VMS::Filespec::unixify($home);
-		$home =~ s#/$##;
-	}
+    if ( $^O eq 'VMS' ) {
 
-	unless (defined $home) {
-		my @info = eval { getpwuid $> };
-		skip "No home directory for tilde-expansion tests", 8 if $@ or !defined $info[7];
-		$home = $info[7];
-	}
+        # Convert the path to UNIX format, trim off the trailing slash
+        $home = VMS::Filespec::unixify($home);
+        $home =~ s#/$##;
+    }
 
-	is( detildefy('~'),	$home);
+    if ( $^O eq 'cygwin' ) {
+        $home = $ENV{HOME} if ( exists $ENV{HOME} );
+    }
 
-	is( detildefy('~/fooxzy'), "$home/fooxzy");
+    unless ( defined $home ) {
+        my @info = eval { getpwuid $> };
+        skip "No home directory for tilde-expansion tests", 8
+          if $@
+          or !defined $info[7];
+        $home = $info[7];
+    }
 
-	is( detildefy('~/ fooxzy'), "$home/ fooxzy");
+    is( detildefy('~'), $home );
 
-	is( detildefy('~/fo o'), "$home/fo o");
+    is( detildefy('~/fooxzy'), "$home/fooxzy" );
 
-	is( detildefy('fooxzy~'), 'fooxzy~');
+    is( detildefy('~/ fooxzy'), "$home/ fooxzy" );
 
-	# Test when HOME is different from getpwuid(), as in sudo.
-	{
-		local $ENV{HOME} = '/wibble/whomp';
-		local $ENV{USERPROFILE} = $ENV{HOME};
+    is( detildefy('~/fo o'), "$home/fo o" );
 
-		is( detildefy('~'), "/wibble/whomp");
-	}
+    is( detildefy('fooxzy~'), 'fooxzy~' );
 
-	skip "On OS/2 EMX all users are equal", 2 if $^O eq 'os2';
-	is( detildefy('~~'), '~~' );
-	is( detildefy('~ fooxzy'), '~ fooxzy' );
+    # Test when HOME is different from getpwuid(), as in sudo.
+    {
+        local $ENV{HOME}        = '/wibble/whomp';
+        local $ENV{USERPROFILE} = $ENV{HOME};
+
+        is( detildefy('~'), "/wibble/whomp" );
+    }
+
+    skip "On OS/2 EMX all users are equal", 2 if $^O eq 'os2';
+    is( detildefy('~~'),       '~~' );
+    is( detildefy('~ fooxzy'), '~ fooxzy' );
 }
 
 # Again, with named users
 SKIP: {
-	my @info = eval { getpwuid $> };
-	skip "No home directory for tilde-expansion tests", 1 if $@ or !defined $info[7] or !defined $info[0];
-	my ($me, $home) = @info[0,7];
+    my @info = eval { getpwuid $> };
+    skip "No home directory for tilde-expansion tests", 1
+      if $@
+      or !defined $info[7]
+      or !defined $info[0];
+    my ( $me, $home ) = @info[ 0, 7 ];
 
-	my $expected = "$home/fooxzy";
+    my $expected = "$home/fooxzy";
 
-	if ($^O eq 'VMS') {
-		# Convert the path to UNIX format and trim off the trailing slash
-		$home = VMS::Filespec::unixify($home);
-		$home =~ s#/$##;
-		$expected = $home . '/../[^/]+' . '/fooxzy';
-	}
-	like( detildefy("~$me/fooxzy"), qr(\Q$expected\E)i );
+    if ( $^O eq 'VMS' ) {
+
+        # Convert the path to UNIX format and trim off the trailing slash
+        $home = VMS::Filespec::unixify($home);
+        $home =~ s#/$##;
+        $expected = $home . '/../[^/]+' . '/fooxzy';
+    }
+    like( detildefy("~$me/fooxzy"), qr(\Q$expected\E)i );
 }
 


### PR DESCRIPTION
extutils-helpers fails in t/tilde.t, see report below, because $ENV{USERPROFILE} contains a windows path.

I don't know when you'd want $ENV{USERPROFILE} for home, but I believe that cygwin always defines $HOME, so I fixed test accordingly

PS: Do you want to update copyright date in dist.ini?

```
t/tilde.t .................... 1/9
#   Failed test at t/tilde.t line 26.
#          got: '/home/maurice'
#     expected: 'C:\Users\maurice'

#   Failed test at t/tilde.t line 28.
#          got: '/home/maurice/fooxzy'
#     expected: 'C:\Users\maurice/fooxzy'

#   Failed test at t/tilde.t line 30.
#          got: '/home/maurice/ fooxzy'
#     expected: 'C:\Users\maurice/ fooxzy'

#   Failed test at t/tilde.t line 32.
#          got: '/home/maurice/fo o'
#     expected: 'C:\Users\maurice/fo o'
# Looks like you failed 4 tests of 9.
```
