### PR TITLE
fix dependency for Test::More, done_testing requires Test::More >= 0.88

### DIFF
--- a/t/man_pagename.t
+++ b/t/man_pagename.t
@@ -2,7 +2,7 @@
 
 use strict;
 use warnings FATAL => 'all';
-use Test::More;
+use Test::More 0.88;
 use Config;
 use File::Spec::Functions qw/catfile/;
 use ExtUtils::Helpers qw/man1_pagename man3_pagename/;


### PR DESCRIPTION
Test is failing when Test:More is lower than 0.88.
t/man_pagename...............Bareword "done_testing" not allowed while "strict subs" in use at t/man_pagename.t line 24.
Execution of t/man_pagename.t aborted due to compilation errors.
