### PR TITLE
Fix startperl limitation (incompatibility with /usr/bin/env perl). To fix it, do not use -w switch in make_exec test but instead enable with use warnings;

### DIFF
--- a/t/make_executable.t
+++ b/t/make_executable.t
@@ -12,7 +12,7 @@ my $filename = 'test_exec';
 my @files;
 
 open my $out, '>', $filename or die "Couldn't create $filename: $!";
-print $out "#! perl -w\nexit \$ARGV[0];\n";
+print $out "#! perl \nuse warnings;\nexit \$ARGV[0];\n";
 close $out;
 
 make_executable($filename);


### PR DESCRIPTION
In this test, using -w in the shebang prevents compiling perl with startperl like /usr/bin/env perl (apparently not always but at least on most systems including GNU/Linux). We can enable warnings with `use warnings;` instead.

When you use the configure option startperl to use env instead of perl binary like this : 

`./Configure -des -Dstartperl='#!/usr/bin/env perl'`

I get thes failing tests due to the warning switch :

```
PERL_DL_NONLAZY=1 "/opt/perl/bin/perl" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'blib/lib', 'blib/arch')" t/*.t
t/make_executable.t ... /usr/bin/env: ‘perl -w’: No such file or directory
t/make_executable.t ... 1/7 
#   Failed test 'test_exec 42 return value ok'
#   at t/make_executable.t line 25.
#          got: '127'
#     expected: '42'
/usr/bin/env: ‘perl -w’: No such file or directory

#   Failed test 'test_exec 51 return value ok'
#   at t/make_executable.t line 25.
#          got: '127'
#     expected: '51'
/usr/bin/env: ‘perl -w’: No such file or directory

#   Failed test 'test_exec 0 return value ok'
#   at t/make_executable.t line 25.
#          got: '127'
#     expected: '0'
# Looks like you failed 3 tests of 7.
t/make_executable.t ... Dubious, test returned 3 (wstat 768, 0x300)
Failed 3/7 subtests 
	(less 1 skipped subtest: 3 okay)
t/man_pagename.t ...... ok   
t/split_like_shell.t .. ok     
t/tilde.t ............. ok   

Test Summary Report
-------------------
t/make_executable.t (Wstat: 768 Tests: 7 Failed: 3)
  Failed tests:  2, 4, 6
  Non-zero exit status: 3
Files=4, Tests=30,  0 wallclock secs ( 0.02 usr  0.01 sys +  0.23 cusr  0.03 csys =  0.29 CPU)
Result: FAIL
Failed 1/4 test programs. 3/30 subtests failed.
Makefile:873: recipe for target 'test_dynamic' failed
make: *** [test_dynamic] Error 255
```
Here is the script I use to reproduce this bug (I build 5.10.1 on Ubuntu 18.04.2) : 

```
#!/bin/bash
 
version="5.10.1"
name="perl-$version"
tarball="$name.tar.gz"
url="https://www.cpan.org/src/5.0/$tarball"

echo $version
echo $name
echo $tarball
echo $url

test -f $tarball && rm $tarball
test -d /opt/perl && rm /opt/perl -Rf
test -d sources && rm sources -Rf
test -f $name && rm $name -Rf

wget $url
tar xvzf $tarball
mv $name sources

sudo cpanm Devel::PatchPerl
patchperl ./sources $version

cd sources

./Configure -des -Dbin=/opt/perl/bin -Dprivlib=.../../lib -Darchlib=.../../lib -Dsitelib=.../../lib -Dsitearch=.../../ -Duserelocatableinc -Dstartperl='#!/usr/bin/env perl' -Dlddlflags=-shared -Dlibs='-lm -ldl' -Duseshrplib -Dlibperl=libperl.so.5.10.1 -Dcc=gcc -Dld=gcc -Dcccdlflags=-fPIC -Dusedl -Ddlsrc=dl_dlopen.xs
make
make install
export set LD_LIBRARY_PATH=/opt/perl/lib/CORE/:$LD_LIBRARY_PATH
export set PATH=/opt/perl/bin:$PATH
curl -L https://cpanmin.us | /opt/perl/bin/perl - App::cpanminus
/opt/perl/bin/cpanm ExtUtils::Helpers
```

Thank you in advance ! :)
